### PR TITLE
Modified the encoder to follow the flow diagram from the HDMI

### DIFF
--- a/svosrc/svo_defines.py
+++ b/svosrc/svo_defines.py
@@ -81,7 +81,7 @@ function integer svo_clog2; \\
     if (v > 0) \\
       v = v - 1; \\
     svo_clog2 = 0; \\
-    while (v) begin \\
+    while (v != 0) begin \\
       v = v >> 1; \\
       svo_clog2 = svo_clog2 + 1; \\
     end \\

--- a/svosrc/svo_defines.vh
+++ b/svosrc/svo_defines.vh
@@ -675,7 +675,7 @@ function integer svo_clog2; \
     if (v > 0) \
       v = v - 1; \
     svo_clog2 = 0; \
-    while (v) begin \
+    while (v != 0) begin \
       v = v >> 1; \
       svo_clog2 = svo_clog2 + 1; \
     end \


### PR DESCRIPTION
I modified the encoder to follow the flow diagram from the HDMI spec.  While the prior encoder did produce good decoded pixels under ideal conditions it did not seem to follow the encoder flow diagram in the spec and this resulted in a DC bias with certain pixel patterns.  For example, a long run of black (0xFFFFFF) pixels gradually accumulated a DC bias by transmitting encoded data with more 1's than 0's pixel after pixel.  This eventually charges the HDMI cable's inherent capacitance and the resulting DC offset confused the monitor's HDMI receiver.  Bad pixels were then seen on the display as a result.  This varies from one monitor to the next depending on the robustness of the HDMI receiver.

The fix follows the spec resulting in a long term DC balance.  After implementing the fix in an FPGA no further monitor corruption issues were seen across multiple monitors.  Simulations show the decoded pixels are the same between the old and new implementation.  Several hundred thousand random pixels were simulated.

I attempted to keep as much code the same as practical and in the original style.  But I did change some names to match the HDMI spec's encoder flow diagram.  This should help others compare the spec to the encoder RTL.